### PR TITLE
switch to persistent data storage for notification state

### DIFF
--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -126,7 +126,7 @@ public class PushPlugin extends CordovaPlugin {
         super.initialize(cordova, webView);
         gForeground = true;
 
-		GCMIntentService.resetNewMessageCounter();
+		GCMIntentService.resetNewMessageCounter(getApplicationContext());
 		final NotificationManager notificationManager = (NotificationManager) cordova.getActivity().getSystemService(Context.NOTIFICATION_SERVICE);
 		notificationManager.cancelAll();
     }
@@ -144,7 +144,7 @@ public class PushPlugin extends CordovaPlugin {
         super.onResume(multitasking);
         gForeground = true;
 
-		GCMIntentService.resetNewMessageCounter();
+		GCMIntentService.resetNewMessageCounter(getApplicationContext());
 		final NotificationManager notificationManager = (NotificationManager) cordova.getActivity().getSystemService(Context.NOTIFICATION_SERVICE);
 		notificationManager.cancelAll();
     }


### PR DESCRIPTION
the original implementation had a problem, which eventually lead to
duplicated notification messages on Android after some period of time.
This implementation uses SharedPreferences as a data store to make the
state persistent for the App.
